### PR TITLE
feat: add basic ACL implementation

### DIFF
--- a/examples/acl_model.conf
+++ b/examples/acl_model.conf
@@ -1,0 +1,11 @@
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = r.sub == p.sub && r.obj == p.obj && r.act == p.act

--- a/examples/acl_policy.csv
+++ b/examples/acl_policy.csv
@@ -1,0 +1,2 @@
+p, alice, target_topic, READ
+p, bob, target_topic, WRITE

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.casbin</groupId>
+    <artifactId>kafka-casbin</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <jcasbin.version>1.19.0</jcasbin.version>
+        <junit.version>4.13.2</junit.version>
+        <slf4j.version>1.7.25</slf4j.version>
+        <kafka.version>2.8.0</kafka.version>
+        <mockito.version>4.1.0</mockito.version>
+        <assertj.version>3.21.0</assertj.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.casbin</groupId>
+            <artifactId>jcasbin</artifactId>
+            <version>${jcasbin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.13</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/src/main/java/org/casbin/kafka/authorizer/CasbinAuthorizer.java
+++ b/src/main/java/org/casbin/kafka/authorizer/CasbinAuthorizer.java
@@ -1,0 +1,103 @@
+// Copyright 2021 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.casbin.kafka.authorizer;
+
+import org.apache.kafka.common.Endpoint;
+import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclBindingFilter;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.server.authorizer.*;
+import org.casbin.jcasbin.main.Enforcer;
+import org.casbin.kafka.authorizer.config.CasbinAuthorizerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+
+/**
+ * Kafka Authorizer implementation with Casbin.
+ *
+ * @author Yixiang Zhao (@seriouszyx)
+ * @date 2021-11-22 18:56
+ **/
+public class CasbinAuthorizer implements Authorizer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CasbinAuthorizer.class);
+    private CasbinAuthorizerConfig config;
+    private Enforcer enforcer;
+
+    public CasbinAuthorizer() {
+    }
+
+    @Override
+    public Map<Endpoint, ? extends CompletionStage<Void>> start(AuthorizerServerInfo authorizerServerInfo) {
+        enforcer = new Enforcer(config.getModel(), config.getPolicy());
+        return authorizerServerInfo.endpoints().stream()
+                .collect(Collectors.toMap(
+                    endpoint -> endpoint,
+                    endpoint -> CompletableFuture.completedFuture(null)
+                ));
+    }
+
+    @Override
+    public List<AuthorizationResult> authorize(AuthorizableRequestContext authorizableRequestContext, List<Action> list) {
+        KafkaPrincipal kafkaPrincipal = authorizableRequestContext.principal();
+        List<AuthorizationResult> results = new ArrayList<>(list.size());
+        for (Action action : list) {
+            boolean result = enforcer.enforce(kafkaPrincipal.getName(), action.resourcePattern().name(), action.operation().name());
+            results.add(result ? AuthorizationResult.ALLOWED : AuthorizationResult.DENIED);
+            if (result) {
+                LOGGER.info("[ALLOW] Auth request {} on {}:{} by {} {}",
+                        action.operation().name(), action.resourcePattern().resourceType(), action.resourcePattern().name(),
+                        kafkaPrincipal.getPrincipalType(), kafkaPrincipal.getName());
+            } else {
+                LOGGER.info("[DENY] Auth request {} on {}:{} by {} {}",
+                        action.operation().name(), action.resourcePattern().resourceType(), action.resourcePattern().name(),
+                        kafkaPrincipal.getPrincipalType(), kafkaPrincipal.getName());
+            }
+        }
+        return results;
+    }
+
+    @Override
+    public List<? extends CompletionStage<AclCreateResult>> createAcls(AuthorizableRequestContext authorizableRequestContext, List<AclBinding> list) {
+        return null;
+    }
+
+    @Override
+    public List<? extends CompletionStage<AclDeleteResult>> deleteAcls(AuthorizableRequestContext authorizableRequestContext, List<AclBindingFilter> list) {
+        return null;
+    }
+
+    @Override
+    public Iterable<AclBinding> acls(AclBindingFilter aclBindingFilter) {
+        return null;
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+
+    @Override
+    public void configure(Map<String, ?> map) {
+        config = new CasbinAuthorizerConfig(map);
+    }
+}

--- a/src/main/java/org/casbin/kafka/authorizer/config/CasbinAuthorizerConfig.java
+++ b/src/main/java/org/casbin/kafka/authorizer/config/CasbinAuthorizerConfig.java
@@ -1,0 +1,60 @@
+// Copyright 2021 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.casbin.kafka.authorizer.config;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+import java.util.Map;
+
+/**
+ * Configuration for the CasbinAuthorizer.
+ *
+ * @author Yixiang Zhao (@seriouszyx)
+ * @date 2021-11-22 19:25
+ **/
+public class CasbinAuthorizerConfig extends AbstractConfig {
+
+    private static final String CASBIN_MODEL_CONF = "casbin.authorizer.model";
+    private static final String CASBIN_POLICY_CONF = "casbin.authorizer.policy";
+
+    public CasbinAuthorizerConfig(Map<?, ?> originals) {
+        super(configDef(), originals);
+    }
+
+    private static ConfigDef configDef() {
+        return new ConfigDef()
+                .define(
+                    CASBIN_MODEL_CONF,
+                    ConfigDef.Type.STRING,
+                    ConfigDef.NO_DEFAULT_VALUE,
+                    ConfigDef.Importance.HIGH,
+                    "The path to mode.conf"
+                ).define(
+                    CASBIN_POLICY_CONF,
+                    ConfigDef.Type.STRING,
+                    ConfigDef.NO_DEFAULT_VALUE,
+                    ConfigDef.Importance.HIGH,
+                    "The path to policy.csv"
+                );
+    }
+
+    public String getModel() {
+        return getString(CASBIN_MODEL_CONF);
+    }
+
+    public String getPolicy() {
+        return getString(CASBIN_POLICY_CONF);
+    }
+}

--- a/src/test/java/org/casbin/kafka/authorizer/CasbinAuthorizerConfigTest.java
+++ b/src/test/java/org/casbin/kafka/authorizer/CasbinAuthorizerConfigTest.java
@@ -1,0 +1,40 @@
+// Copyright 2021 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.casbin.kafka.authorizer;
+
+import org.casbin.kafka.authorizer.config.CasbinAuthorizerConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test CasbinAuthorizerConfig.
+ *
+ * @author Yixiang Zhao (@seriouszyx)
+ * @date 2021-11-25 22:00
+ **/
+public class CasbinAuthorizerConfigTest {
+
+    @Test
+    public void testConfig() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("casbin.authorizer.model", "examples/acl.model");
+        properties.put("casbin.authorizer.policy", "examples/acl.policy");
+        CasbinAuthorizerConfig config = new CasbinAuthorizerConfig(properties);
+        Assert.assertEquals("examples/acl.model", config.getModel());
+        Assert.assertEquals("examples/acl.policy", config.getPolicy());
+    }
+}

--- a/src/test/java/org/casbin/kafka/authorizer/CasbinAuthorizerTest.java
+++ b/src/test/java/org/casbin/kafka/authorizer/CasbinAuthorizerTest.java
@@ -1,0 +1,118 @@
+// Copyright 2021 The casbin Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package org.casbin.kafka.authorizer;
+
+import org.apache.kafka.common.Endpoint;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.network.ClientInformation;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.requests.RequestContext;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.server.authorizer.Action;
+import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
+import org.apache.kafka.server.authorizer.AuthorizationResult;
+import org.apache.kafka.server.authorizer.AuthorizerServerInfo;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test CasbinAuthorizer.
+ *
+ * @author Yixiang Zhao (@seriouszyx)
+ * @date 2021-11-26 18:33
+ **/
+public class CasbinAuthorizerTest {
+
+    private static final ResourcePattern TOPIC_RESOURCE = new ResourcePattern(
+            org.apache.kafka.common.resource.ResourceType.TOPIC,
+            "target_topic",
+            PatternType.LITERAL
+    );
+
+    private CasbinAuthorizer authorizer;
+
+    @Before
+    public void init() {
+        authorizer = new CasbinAuthorizer();
+        Map<String, String> configs = new HashMap<>();
+        configs.put("casbin.authorizer.model", "examples/acl_model.conf");
+        configs.put("casbin.authorizer.policy", "examples/acl_policy.csv");
+        authorizer.configure(configs);
+    }
+
+    @Test
+    public void testStart() {
+        List<Endpoint> endpoints = Arrays.asList(
+                new Endpoint("PLAINTEXT", SecurityProtocol.PLAINTEXT, "localhost", 9092),
+                new Endpoint("SSL", SecurityProtocol.SSL, "localhost", 9093)
+        );
+        AuthorizerServerInfo serverInfo = mock(AuthorizerServerInfo.class);
+        when(serverInfo.endpoints()).thenReturn(endpoints);
+        assertThat(authorizer.start(serverInfo)).allSatisfy(
+                (endpoint, completionStage) -> assertThatNoException().isThrownBy(
+                        () -> completionStage.toCompletableFuture().get(0, TimeUnit.MICROSECONDS)
+                )
+        );
+    }
+
+    @Test
+    public void testCasbinAuthorizer() {
+        AuthorizerServerInfo serverInfo = mock(AuthorizerServerInfo.class);
+        when(serverInfo.endpoints()).thenReturn(new ArrayList<>());
+        authorizer.start(serverInfo);
+        // Basic ACL checks
+        testSingleAction(requestContext("User", "alice"), action(AclOperation.READ, TOPIC_RESOURCE), true);
+        testSingleAction(requestContext("User", "bob"), action(AclOperation.WRITE, TOPIC_RESOURCE), true);
+        testSingleAction(requestContext("User", "alice"), action(AclOperation.WRITE, TOPIC_RESOURCE), false);
+        testSingleAction(requestContext("User", "bob"), action(AclOperation.READ, TOPIC_RESOURCE), false);
+    }
+
+    private void testSingleAction(AuthorizableRequestContext context, Action action, boolean allowed) {
+        List<AuthorizationResult> results = authorizer.authorize(context, Arrays.asList(action));
+        for (AuthorizationResult result : results) {
+            assertThat(result).isEqualTo(allowed ? AuthorizationResult.ALLOWED : AuthorizationResult.DENIED);
+        }
+    }
+
+    private AuthorizableRequestContext requestContext(String principalType, String name) {
+        return new RequestContext(
+                new RequestHeader(ApiKeys.METADATA, (short) 0, "test-client-id", 123),
+                "test-connection-id",
+                InetAddress.getLoopbackAddress(),
+                new KafkaPrincipal(principalType, name),
+                new ListenerName("PLAINTEXT"),
+                SecurityProtocol.PLAINTEXT,
+                ClientInformation.EMPTY,
+                false
+        );
+    }
+
+    private Action action(AclOperation operation, ResourcePattern resourcePattern) {
+        return new Action(operation, resourcePattern, 0, true, true);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Yixiang Zhao <seriouszyx@foxmail.com

Fix: https://github.com/jcasbin/kafka-casbin/issues/1

I have implemented the ACL authorizer for Kafka with Casbin basically. The UML diagram is as below. The basic method, start and authorize, has been done in this PR.

![kafka-casbin](https://user-images.githubusercontent.com/33992371/143727733-b4bdbdfb-e42b-48c0-a217-17783d52d717.png)

